### PR TITLE
Improve module install tests

### DIFF
--- a/dnf-docker-test/features/module-install-1.feature
+++ b/dnf-docker-test/features/module-install-1.feature
@@ -5,15 +5,123 @@ Feature: Installing module profiles
       Given I run steps from file "modularity-repo-1.setup"
         And I run steps from file "modularity-repo-2.setup"
        When I enable repository "modularityABDE"
+        And I enable repository "modularityX"
         And I successfully run "dnf makecache"
 
 #  Scenario: I can install a module profile without specifying a profile
 #      Given I successfully run "dnf module enable ModuleB:f26"
 #       When I successfully run "dnf module install ModuleB"
 
-  Scenario: I can install a specific module profile
-      Given I successfully run "dnf module enable ModuleA:f26"
-       When I successfully run "dnf module install -y ModuleA/minimal"
+#  Scenario: I can install a specific module profile
+#      Given I successfully run "dnf module enable ModuleA:f26"
+#       When I successfully run "dnf module install -y ModuleA/minimal"
 
-  Scenario: I can install additional module profile
-       When I successfully run "dnf module install --assumeyes ModuleA/client"
+#  Scenario: I can install additional module profile
+#       When I successfully run "dnf module install --assumeyes ModuleA/client"
+#
+  Scenario: I can install a module profile for an enabled module stream
+      Given I successfully run "dnf module enable ModuleA:f26"
+       When I save rpmdb
+        And I successfully run "dnf module install -y ModuleA/minimal"
+       Then a module "ModuleA" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 2     |
+        And rpmdb changes are
+         | State     | Packages       |
+         | installed | TestA/1-2.modA |
+
+  Scenario: I can install a module profile by name:stream/profile
+      Given I successfully run "dnf module remove -y ModuleA:f26"
+       When I save rpmdb
+        And I successfully run "dnf module install -y ModuleA:f26/minimal"
+       Then a module "ModuleA" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 2     |
+        And rpmdb changes are
+         | State     | Packages       |
+         | installed | TestA/1-2.modA |
+
+  Scenario: I can install a module profile by name:stream:version/profile
+      Given I successfully run "dnf module remove -y ModuleA:f26"
+       When I save rpmdb
+        And I successfully run "dnf module install -y ModuleA:f26:2/minimal"
+       Then a module "ModuleA" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 2     |
+        And rpmdb changes are
+         | State     | Packages       |
+         | installed | TestA/1-2.modA |
+
+  Scenario: I can install multiple module profiles at the same time
+      Given I successfully run "dnf module remove -y ModuleA:f26"
+       When I save rpmdb
+        And I successfully run "dnf module install -y ModuleA/minimal ModuleA/devel"
+       Then a module "ModuleA" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 2     |
+        And rpmdb changes are
+         | State     | Packages                       |
+         | installed | TestA/1-2.modA, TestD/1-1.modA |
+
+  Scenario: I am given information about which module packages are being installed when installing a module profile
+      Given I successfully run "dnf module remove -y ModuleA:f26"
+       When I save rpmdb
+        And I successfully run "dnf module install -y ModuleA/default"
+       Then a module "ModuleA" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 2     |
+        And the command stdout section "Installing module packages:" should match regexp "TestA.*1-2.modA"
+        And the command stdout section "Installing module packages:" should match regexp "TestB.*1-1.modA"
+        And the command stdout section "Installing module packages:" should match regexp "TestC.*1-2.modA"
+
+  Scenario: Installing a module profile with RPMs manually installed previously should do nothing
+      Given I successfully run "dnf module remove -y ModuleA:f26"
+       When I successfully run "dnf install -y TestA-1-2.modA"
+        And I save rpmdb
+        And I successfully run "dnf module install -y ModuleA:f26:2/minimal"
+       Then a module "ModuleA" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 2     |
+        And rpmdb does not change
+        And the command stdout should match line by line regexp
+            """
+            ?Last metadata expiration check
+            Nothing to install. Enabled modules: ModuleA:f26.
+            """
+
+  # currently know to fail since dnf does not track the version of ModuleD
+  # even though it has installed a package from it
+  Scenario: I can install a module default profile with dependencies for an enabled module stream
+      Given I successfully run "dnf module enable ModuleE:f26"
+       When I save rpmdb
+        And I successfully run "dnf module install -y ModuleE"
+       Then a module "ModuleD" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 1     |
+        And a module "ModuleE" config file should contain
+         | Key      | Value |
+         | enabled  | 1     |
+         | stream   | f26   |
+         | version  | 1     |
+        And rpmdb changes are
+         | State     | Packages                       |
+         | installed | TestP/1-1.modE, TestM/1-1.modD |
+
+  Scenario: A proper error message is displayed when I try to install a non-existant module using group syntax
+       When I run "dnf install @ModuleC"
+       Then the command exit code is 1
+        And the command stderr should match regexp "Module or Group 'ModuleC' does not exist"

--- a/dnf-docker-test/features/module-install-1.feature
+++ b/dnf-docker-test/features/module-install-1.feature
@@ -101,25 +101,3 @@ Feature: Installing module profiles
             Nothing to install. Enabled modules: ModuleA:f26.
             """
 
-  Scenario: I can install a module default profile with dependencies for an enabled module stream
-      Given I successfully run "dnf module enable ModuleE:f26"
-       When I save rpmdb
-        And I successfully run "dnf module install -y ModuleE"
-       Then a module "ModuleD" config file should contain
-         | Key      | Value |
-         | enabled  | 1     |
-         | stream   | f26   |
-         # version  | 1     | # note: skip version check since module is only enabled, not installed
-        And a module "ModuleE" config file should contain
-         | Key      | Value |
-         | enabled  | 1     |
-         | stream   | f26   |
-         | version  | 1     |
-        And rpmdb changes are
-         | State     | Packages                       |
-         | installed | TestP/1-1.modE, TestM/1-1.modD |
-
-  Scenario: A proper error message is displayed when I try to install a non-existant module using group syntax
-       When I run "dnf install @ModuleC"
-       Then the command exit code is 1
-        And the command stderr should match regexp "Module or Group 'ModuleC' does not exist"

--- a/dnf-docker-test/features/module-install-1.feature
+++ b/dnf-docker-test/features/module-install-1.feature
@@ -101,8 +101,6 @@ Feature: Installing module profiles
             Nothing to install. Enabled modules: ModuleA:f26.
             """
 
-  # currently know to fail since dnf does not track the version of ModuleD
-  # even though it has installed a package from it
   Scenario: I can install a module default profile with dependencies for an enabled module stream
       Given I successfully run "dnf module enable ModuleE:f26"
        When I save rpmdb
@@ -111,7 +109,7 @@ Feature: Installing module profiles
          | Key      | Value |
          | enabled  | 1     |
          | stream   | f26   |
-         | version  | 1     |
+         # version  | 1     | # note: skip version check since module is only enabled, not installed
         And a module "ModuleE" config file should contain
          | Key      | Value |
          | enabled  | 1     |


### PR DESCRIPTION
As noted in `module-install-1.feature`, the "I can install a module default profile with dependencies for an enabled module stream" scenario fails since dnf is apparently not tracking the version of ModuleD--even though a required package has been installed from it.

Martin suggest that required modules should only be enabled, but I think this is really a bug.

