### PR TITLE
added (set) checking approach to the module config file check

### DIFF
--- a/dnf-docker-test/features/steps/file_steps.py
+++ b/dnf-docker-test/features/steps/file_steps.py
@@ -150,7 +150,7 @@ def step_an_ini_file_filepath_modified_with(ctx, filepath):
 
 
 @then('an INI file "{filepath}" should contain')
-def step_an_ini_file_filepath_should_contain(ctx, filepath):
+def step_an_ini_file_filepath_should_contain(ctx, filepath, extra_value_processing = False):
     """
     Tests whether an INI file contain respective Section, Key, Value
     triples.
@@ -184,7 +184,16 @@ def step_an_ini_file_filepath_should_contain(ctx, filepath):
                                      "No such option '%s' in section '%s' in '%s'" % (key, section, filepath))
             value = settings[key]
             ini_value = conf.get(section, key)
-            ctx.assertion.assertEquals(value, ini_value)
+            if not extra_value_processing:
+                ctx.assertion.assertEquals(value, ini_value)
+            else:  # an extra processing is enabled
+                if value.startswith('(set)'):
+                    # consider the value to be command or \n separated set of values
+                    value_set = map(str.strip, value[5:].split(","))
+                    ini_value_set = map(str.strip, ini_value.replace("\n", ",").split(","))
+                    ctx.assertion.assertCountEqual(value_set, ini_value_set)
+                else:  # fallback
+                    ctx.assertion.assertEquals(value, ini_value)
 
 
 @given('I run steps from file "{filepath}"')

--- a/dnf-docker-test/features/steps/module_steps.py
+++ b/dnf-docker-test/features/steps/module_steps.py
@@ -28,9 +28,22 @@ def step_a_module_modulename_should_contain(ctx, modulename):
             Then a module ModuleA config file should contain
                | Key    | Value |
                | locked | 1     |
+
+         Scenario: Testing a module profile installation
+            When I successfully run "dnf -y module install ModuleA/minimal"
+             And I successfully run "dnf -y module install ModuleA/default"
+            Then a module ModuleA config file should contain
+               | Key      | Value                 |
+               | profiles | (set) minimal,default |
+
+    .. note::
+       The (set) here enables the extra value processing which tests than
+       value expected contains the same elements as actual, regardless of 
+       their order.
+
     """
     modulename = modulename.strip('"')
     skv_table = table_utils.convert_table_kv_to_skv(ctx.table, HEADINGS_INI, [modulename])
     ctx.table = skv_table
     filepath = '/etc/dnf/modules.d/{!s}.module'.format(modulename)
-    step_an_ini_file_filepath_should_contain(ctx, filepath)
+    step_an_ini_file_filepath_should_contain(ctx, filepath, extra_value_processing = True)


### PR DESCRIPTION
This is necessary for proper testing of installed profiles in module config file.
Example included.