### PR TITLE
Fix incorrect module Dist Tags in repo definition

### DIFF
--- a/dnf-docker-test/features/modularity-repo-4.setup
+++ b/dnf-docker-test/features/modularity-repo-4.setup
@@ -7,16 +7,16 @@ Given repository "modularityM" with packages
      | modM/TestMBX | Version  | 1      |
      |              | Release  | 1      |
      |              | Requires | TestMX |
-     | modM/TestMX  | Version  | 1      |
+     | modMX/TestMX | Version  | 1      |
      |              | Release  | 1      |
      | modM/TestMC  | Version  | 1      |
      |              | Release  | 1      |
      | modM/TestMCY | Version  | 1      |
      |              | Release  | 1      |
      |              | Requires | TestMY |
-     | modM/TestMY  | Version  | 1      |
+     | modMY/TestMY | Version  | 1      |
      |              | Release  | 1      |
-     | modM/TestMZ  | Version  | 1      |
+     | modMZ/TestMZ | Version  | 1      |
      |              | Release  | 1      |
   And a file "modules.yaml" with type "modules" added into repository "modularityM"
       """
@@ -81,7 +81,7 @@ Given repository "modularityM" with packages
           default:
             rpms: [TestMX]
         artifacts:
-          rpms: ["TestMX-0:1-1.modM.noarch"]
+          rpms: ["TestMX-0:1-1.modMX.noarch"]
         components:
           rpms:
             TestMX: {rationale: 'rationale for TestMX'}
@@ -100,7 +100,7 @@ Given repository "modularityM" with packages
           default:
             rpms: [TestMY]
         artifacts:
-          rpms: ["TestMY-0:1-1.modM.noarch"]
+          rpms: ["TestMY-0:1-1.modMY.noarch"]
         components:
           rpms:
             TestMY: {rationale: 'rationale for TestMY'}
@@ -122,7 +122,7 @@ Given repository "modularityM" with packages
           default:
             rpms: [TestMZ]
         artifacts:
-          rpms: ["TestMZ-0:1-1.modM.noarch"]
+          rpms: ["TestMZ-0:1-1.modMZ.noarch"]
         components:
           rpms:
             TestMZ: {rationale: 'rationale for TestMZ'}
@@ -144,7 +144,7 @@ Given repository "modularityM" with packages
           default:
             rpms: [TestMZ]
         artifacts:
-          rpms: ["TestMZ-0:1-1.modM.noarch"]
+          rpms: ["TestMZ-0:1-1.modMZ.noarch"]
         components:
           rpms:
             TestMZ: {rationale: 'rationale for TestMZ'}

--- a/dnf-docker-test/features/module-enable-4.feature
+++ b/dnf-docker-test/features/module-enable-4.feature
@@ -67,8 +67,8 @@ Feature: Enabling module stream with dependencies
           | stream  | f27   |
           | version | -1    |
         And rpmdb changes are
-          | State   | Packages                                                            |
-          | removed | TestMA/1-1.modM, TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modM |
+          | State   | Packages                                                             |
+          | removed | TestMA/1-1.modM, TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modMX |
 
   # https://bugzilla.redhat.com/show_bug.cgi?id=1581160
   @xfail
@@ -98,5 +98,5 @@ Feature: Enabling module stream with dependencies
           | stream  | f27   |
           | version | -1    |
         And rpmdb changes are
-          | State   | Packages                                                                             |
-          | removed | TestMA/1-1.modM, TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modM, TestMZ/1-1.modM |
+          | State   | Packages                                                                               |
+          | removed | TestMA/1-1.modM, TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modMX, TestMZ/1-1.modMZ |

--- a/dnf-docker-test/features/module-install-2.feature
+++ b/dnf-docker-test/features/module-install-2.feature
@@ -21,7 +21,7 @@ Feature: Installing module profiles with dependencies
          # version  | 1     | # note: skip version check since module is only enabled, not installed
         And rpmdb changes are
          | State     | Packages                                                             |
-         | installed | TestMA/1-1.modM, TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modM  | 
+         | installed | TestMA/1-1.modM, TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modMX |
 
   # https://bugzilla.redhat.com/show_bug.cgi?id=1581160
   @xfail
@@ -47,6 +47,6 @@ Feature: Installing module profiles with dependencies
         And rpmdb changes are
          | State     | Packages                                            |
          | unchanged | TestMA/1-1.modM                                     |
-         | installed | TestMC/1-1.modM, TestMCY/1-1.modM, TestMY/1-1.modM  | 
-         | removed   | TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modM  | 
+         | installed | TestMC/1-1.modM, TestMCY/1-1.modM, TestMY/1-1.modMY |
+         | removed   | TestMB/1-1.modM, TestMBX/1-1.modM, TestMX/1-1.modMX |
 


### PR DESCRIPTION
Corrected module-specific packages that were inadvertently defined using the wrong module Dist Tag that could cause unpredictable behavior